### PR TITLE
Use Context vdwLambda parameter to update the Dispersion long-range correction at each time step.

### DIFF
--- a/plugins/amoeba/openmmapi/include/openmm/AmoebaVdwForce.h
+++ b/plugins/amoeba/openmmapi/include/openmm/AmoebaVdwForce.h
@@ -192,20 +192,6 @@ public:
     const std::string& getEpsilonCombiningRule(void) const;
 
     /**
-     * Get VDW Lambda
-     */
-    double getVdwLambda() const {
-        return vdwLambda;
-    }
-
-    /**
-     * Set VDW Lambda
-     */
-    void setVdwLambda(double l) {
-        vdwLambda = l;
-    }
-
-    /**
      * Get number of condensed VDW types/classes
      */
     int getNumCondensedTypes() const;
@@ -400,7 +386,6 @@ private:
     AlchemicalMethod alchemicalMethod;
     int n;
     double alpha;
-    double vdwLambda;
     bool usesVdwpr;
     bool usesLJ;
 

--- a/plugins/amoeba/openmmapi/include/openmm/internal/AmoebaVdwForceImpl.h
+++ b/plugins/amoeba/openmmapi/include/openmm/internal/AmoebaVdwForceImpl.h
@@ -69,7 +69,7 @@ public:
      * Compute the coefficient which, when divided by the periodic box volume, gives the
      * long range dispersion correction to the energy.
      */
-    static double calcDispersionCorrection(const System& system, const AmoebaVdwForce& force);
+    static double calcDispersionCorrection(const System& system, const AmoebaVdwForce& force, double lambda);
     void updateParametersInContext(ContextImpl& context);
 private:
     const AmoebaVdwForce& owner;

--- a/plugins/amoeba/openmmapi/src/AmoebaVdwForce.cpp
+++ b/plugins/amoeba/openmmapi/src/AmoebaVdwForce.cpp
@@ -38,7 +38,7 @@ using namespace OpenMM;
 using std::string;
 using std::vector;
 
-AmoebaVdwForce::AmoebaVdwForce() : nonbondedMethod(NoCutoff), sigmaCombiningRule("CUBIC-MEAN"), epsilonCombiningRule("HHG"), cutoff(1.0e+10), useDispersionCorrection(true), alchemicalMethod(None), n(5), alpha(0.7), vdwLambda(1.0), usesVdwpr(false), usesLJ(false) {
+AmoebaVdwForce::AmoebaVdwForce() : nonbondedMethod(NoCutoff), sigmaCombiningRule("CUBIC-MEAN"), epsilonCombiningRule("HHG"), cutoff(1.0e+10), useDispersionCorrection(true), alchemicalMethod(None), n(5), alpha(0.7), usesVdwpr(false), usesLJ(false) {
 }
 
 int AmoebaVdwForce::addParticle(int parentIndex, double sigma, double epsilon, double reductionFactor, bool isAlchemical) {

--- a/plugins/amoeba/openmmapi/src/AmoebaVdwForceImpl.cpp
+++ b/plugins/amoeba/openmmapi/src/AmoebaVdwForceImpl.cpp
@@ -77,7 +77,7 @@ double AmoebaVdwForceImpl::calcForcesAndEnergy(ContextImpl& context, bool includ
     return 0.0;
 }
 
-double AmoebaVdwForceImpl::calcDispersionCorrection(const System& system, const AmoebaVdwForce& force) {
+double AmoebaVdwForceImpl::calcDispersionCorrection(const System& system, const AmoebaVdwForce& force, double lambda) {
 
     // Amoeba VdW dispersion correction implemented by LPW
     // There is no dispersion correction if PBC is off or the cutoff is set to the default value of ten billion (AmoebaVdwForce.cpp)
@@ -93,7 +93,7 @@ double AmoebaVdwForceImpl::calcDispersionCorrection(const System& system, const 
         int ndelta = int(double(nstep) * (range - cut));
         double rdelta = (range - cut) / double(ndelta);
         double offset = cut - 0.5 * rdelta;
-        double vlambda = force.getVdwLambda();
+        double vlambda = lambda;
         double vlam1 = 1.0 - vlambda;
 
         int n = force.getNumParticles();

--- a/plugins/amoeba/platforms/cuda/src/AmoebaCudaKernels.h
+++ b/plugins/amoeba/platforms/cuda/src/AmoebaCudaKernels.h
@@ -630,7 +630,8 @@ private:
     // Per particle alchemical flag.
     CudaArray isAlchemical;
 
-    double dispersionCoefficient;
+    double dispersionCoefficient0;
+    double dispersionCoefficient1;
     CudaArray sigmaEpsilon;
     CudaArray bondReductionAtoms;
     CudaArray bondReductionFactors;

--- a/plugins/amoeba/platforms/reference/src/AmoebaReferenceKernels.cpp
+++ b/plugins/amoeba/platforms/reference/src/AmoebaReferenceKernels.cpp
@@ -51,7 +51,6 @@
 #include "SimTKReference/AmoebaReferenceHippoNonbondedForce.h"
 
 #include <cmath>
-#include <iostream>
 #ifdef _MSC_VER
 #include <windows.h>
 #endif

--- a/plugins/amoeba/platforms/reference/src/AmoebaReferenceKernels.h
+++ b/plugins/amoeba/platforms/reference/src/AmoebaReferenceKernels.h
@@ -558,7 +558,8 @@ private:
     int useCutoff;
     int usePBC;
     double cutoff;
-    double dispersionCoefficient;
+    double dispersionCoefficient0;
+    double dispersionCoefficient1;
     AmoebaVdwForce::AlchemicalMethod alchemicalMethod;
     int n;
     double alpha;

--- a/plugins/amoeba/serialization/src/AmoebaVdwForceProxy.cpp
+++ b/plugins/amoeba/serialization/src/AmoebaVdwForceProxy.cpp
@@ -78,7 +78,6 @@ void AmoebaVdwForceProxy::serialize(const void* object, SerializationNode& node)
     node.setBoolProperty("useDispersionCorrection", force.getUseDispersionCorrection());
     node.setBoolProperty("usesVdwpr", force.getUsePairwiseVdw());
     node.setBoolProperty("usesLJ", force.getUseLennardJones());
-    node.setDoubleProperty("vdwLambda", force.getVdwLambda());
     if (force.getUsePairwiseVdw()) {
         SerializationNode& vdwTypes = node.createChildNode("VdwTypes");
         for (int ii = 0; ii < force.getNumParticles(); ++ii) {
@@ -143,7 +142,6 @@ void* AmoebaVdwForceProxy::deserialize(const SerializationNode& node) const {
            force->setSoftcoreAlpha(node.getDoubleProperty("alpha"));
 
            force->setUseDispersionCorrection(node.getBoolProperty("useDispersionCorrection"));
-           force->setVdwLambda(node.getDoubleProperty("vdwLambda"));
            bool usesVdwpr = node.getBoolProperty("usesVdwpr");
            if (usesVdwpr) {
                bool usesLJ = node.getBoolProperty("usesLJ");


### PR DESCRIPTION
Using the Context vdwLambda parameter (instead of a AmoebaVdwForce field) is more efficient for algorithms that frequently update the value of lambda.